### PR TITLE
Resolves ReferenceError: async is not defined

### DIFF
--- a/jsShrink.js
+++ b/jsShrink.js
@@ -12,7 +12,7 @@ function jsShrink(input) {
 	return ('\n' + input + '\n').replace(/(?:(^|[-+\([{}=,:;!%^&*|?~]|\/(?![/*])|return|throw)(?:\s|\/\/[^\n]*\n|\/\*(?:[^*]|\*(?!\/))*\*\/)*(\/(?![/*])(?:\\[^\n]|[^[\n\/\\]|\[(?:\\[^\n]|[^\]])+)+\/)|(^|'(?:\\[\s\S]|[^\n'\\])*'|"(?:\\[\s\S]|[^\n"\\])*"|([0-9A-Za-z_$]+)|([-+]+)|.))(?:\s|\/\/[^\n]*\n|\/\*(?:[^*]|\*(?!\/))*\*\/)*/g, function (str, context, regexp, result, word, operator) {
 		if (word) {
 			result = (last == 'word' ? '\n' : (last == 'return' ? ' ' : '')) + result;
-			last = (word == 'return' || word == 'throw' || word == 'break' ? 'return' : 'word');
+			last = (word == 'return' || word == 'throw' || word == 'break' || word == 'async' ? 'return' : 'word');
 		} else if (operator) {
 			result = (last == operator.charAt(0) ? '\n' : '') + result;
 			last = operator.charAt(0);

--- a/jsShrink.php
+++ b/jsShrink.php
@@ -35,7 +35,7 @@ function jsShrinkCallback($match) {
 	list(, $context, $regexp, $result, $word, $operator) = $match;
 	if ($word != '') {
 		$result = ($last == 'word' ? "\n" : ($last == 'return' ? " " : "")) . $result;
-		$last = ($word == 'return' || $word == 'throw' || $word == 'break' ? 'return' : 'word');
+		$last = ($word == 'return' || $word == 'throw' || $word == 'break' || $word == 'async' ? 'return' : 'word');
 	} elseif ($operator) {
 		$result = ($last == $operator[0] ? "\n" : "") . $result;
 		$last = $operator[0];


### PR DESCRIPTION
This allows `await` to be used with `async` functions. Currently when minified, it throws `ReferenceError: async is not defined` error.